### PR TITLE
Added whitespace handling to regexp.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
-  if ((typeof source === "string") && (/^#!/.test(source))) {
+  if ((typeof source === "string") && (/^\s*#!/.test(source))) {
     source = source.replace /^#![^\n\r]*[\r\n]/, ''
   }
 	return source

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
   if ((typeof source === "string") && (/^\s*#!/.test(source))) {
-    source = source.replace /^#![^\n\r]*[\r\n]/, ''
+    source = source.replace /^\s*#![^\n\r]*[\r\n]/, ''
   }
 	return source
 	// this.value = [value];


### PR DESCRIPTION
This update adds whitespace handling to the matching regexp, as I've seen files in some node modules (e.g. JSONStream) contain extra whitespace before the shebang.

Allowing extra whitespace in the beginning is not really inline with the definition of shebangs, but making this loader a bit more generic allows using those files, instead of trying to fix every node module out there.